### PR TITLE
chore(changelog): add changelog generator

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,38 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
+
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }} - [ {{ .Hash.Short }} ]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }})
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+
+{{ range .RevertCommits -}}
+* {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+
+{{ range .MergeCommits -}}
+* {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/Poltergeist/journalp
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+
+<a name="v0.0.1"></a>
+## [v0.0.1](https://github.com/Poltergeist/journalp/compare/v0.0.0...v0.0.1) (2020-06-29)
+
+### Chore
+
+* add gitignore file - [ 2c3114a ](https://github.com/Poltergeist/journalp/commit/2c3114adc91454ea91caf611464c00c20339e414)
+* **gitignore:** add dist to ignored files - [ 0d4146e ](https://github.com/Poltergeist/journalp/commit/0d4146e56308b81d1d863b48af5dd6f0ca7f735b)
+* **gitignore:** add journalp-dir to ignored path - [ c734b10 ](https://github.com/Poltergeist/journalp/commit/c734b10c80e5831eaf309c1799c60a148a988868)
+* **gorealeaser:** add goreleaser config to repository - [ 7e521bf ](https://github.com/Poltergeist/journalp/commit/7e521bf9c65cefd230e585d34bc54c8ba7b1df97)
+
+### Ci
+
+* **goreleaser:** add goreleaser github action - [ df0c7ea ](https://github.com/Poltergeist/journalp/commit/df0c7ea401282e8b0ca0e5ce76b59a112b5dc9dd)
+
+### Feat
+
+* **create entry:** add time header to file - [ 6fda3fa ](https://github.com/Poltergeist/journalp/commit/6fda3faf7d1b06dce5908111c292a7efdd35a081)
+* **create entry:** add timestamp to file as a header - [ b12d771 ](https://github.com/Poltergeist/journalp/commit/b12d771033e0fd2b8251fefbcdb642352612ed49)
+* **create entry:** add create file and insert date header - [ ab11605 ](https://github.com/Poltergeist/journalp/commit/ab11605b72eb3c095ed55656a344f92b0fd20f67)
+* **create entry:** add folder creation - [ 4eacb0d ](https://github.com/Poltergeist/journalp/commit/4eacb0d10a9ae2f2d2bec76857eafed7431943f0)
+* **create entry:** add create entry sub sub command - [ 9ae5e4d ](https://github.com/Poltergeist/journalp/commit/9ae5e4d52629cd838584da93f6051f14038fda34)
+* **root:** add journalp directory output on config read - [ c248e89 ](https://github.com/Poltergeist/journalp/commit/c248e8936fd4b3ffe416a5e134d90b718fec3f1a)
+* **root:** add help description for root command - [ 40c3697 ](https://github.com/Poltergeist/journalp/commit/40c3697d79fefec6238f2dfb83716207ab94c644)
+
+
+<a name="v0.0.0"></a>
+## v0.0.0 (2020-06-29)
+
+### Chore
+
+* initial commit - [ f6db586 ](https://github.com/Poltergeist/journalp/commit/f6db58684e0d6483df890130a806024d2e312823)
+


### PR DESCRIPTION
This introduces git-chglog to the repository to generate a changelog based on
commits. Git-chglog is heavily inspired by conventional changelog.